### PR TITLE
Update Panasonic - 3DO Interactive Multiplayer.json

### DIFF
--- a/clonelists/Panasonic - 3DO Interactive Multiplayer.json
+++ b/clonelists/Panasonic - 3DO Interactive Multiplayer.json
@@ -6,6 +6,13 @@
 		"last updated": "10 April 2021",
 		"minimum version": "0.89"
 	},
+	
+	"categories": {
+		"Panasonic REAL 3DO Interactive Multiplayer - Sampler CD": {
+			"match": "short",
+			"categories": ["Demos"]
+		}
+	},
 
 	"renames": {
 		"Alone in the Dark": [
@@ -117,6 +124,9 @@
 		],
 		"Super Street Fighter II Turbo": [
 			["Super Street Fighter II X - Grand Master Challenge", 1]
+		],
+		"Supreme Warrior (Disc 2)": [
+			["Supreme Warrior (Japan) (Ja,Zh) (Disc 2) (Wind & Fang Tu)", 0]
 		],
 		"Total Eclipse": [
 			["Total Eclipse (DFJN5015ZAZ)", 2]


### PR DESCRIPTION
Added Panasonic REAL 3DO Interactive Multiplayer - Sampler CD > "Demos"
Added Supreme Warrior (Disc 2) in order to have the disc 2 from JP while we're waiting for the US disc 1 to be dumped and available.