### PR TITLE
Update Sega - Dreamcast.json

### DIFF
--- a/clonelists/Sega - Dreamcast.json
+++ b/clonelists/Sega - Dreamcast.json
@@ -55,8 +55,8 @@
 	},
 
 	"removes": {
-    		"Pro Yakyuu Team de Asobou! (Japan)": {},
-		"Pro Yakyuu Team de Asobou Net! (Japan) (Rev A)": {},
+		"Pro Yakyuu Team de Asobou! (Japan)": {},
+		"Pro Yakyuu Team de Asobou Net! (Japan)": {},
 		"Pro Yakyuu Team o Tsukurou! (Japan)": {}
 	},
 
@@ -217,10 +217,6 @@
 		],
 		"POD - Speedzone": [
 			["POD 2 - Multiplayer Online", 1]
-		],
-		"Project Justice": [
-			["Moero! Justice Gakuen", 1],
-			["Project Justice - Rival Schools 2", 1]
 		],
 		"Project Justice": [
 			["Moero! Justice Gakuen", 1],


### PR DESCRIPTION
* Removed from renames "Aero Dancing i" + "Aero Dancing i - Jikai-saku made Matemasen" (the last is the addon disc of the former)

* Added in categories "Checkicco no Miru CD" + "D2 - Original Sound Track" + "dps - Heartbreak Diary" + "Hang the DJ" + "Himitsu - Original Sound Track" + "Kita e. White Illumination - Pure Songs and Pictures" + "Project Berkley" + "Sakura Taisen 3 - Paris wa Moeteiru ka - Sakura Taisen 3 Movie Disc" + "Snappers - 09 Chairs" + "Space Channel 5 Theme Music - Mexican Flyer" + "Virtua Fighter History & VF4"

* Added in removes "Pro Yakyuu Team de Asobou! (Japan)" + "Pro Yakyuu Team de Asobou Net! (Japan) (Rev A)" + "Pro Yakyuu Team o Tsukurou! (Japan)" (they are grouped together in "Pro Yakyuu Team o Tsukurou! & Asobou! (Japan)" with updated 2001 roster)