### PR TITLE
Update Sony - PlayStation.json

### DIFF
--- a/clonelists/Sony - PlayStation.json
+++ b/clonelists/Sony - PlayStation.json
@@ -717,9 +717,8 @@
 		"Capcom vs. SNK Pro": [
 			["Capcom vs. SNK - Millennium Fight 2000 Pro", 1]
 		],
-		"Carnage Heart": [
-			["Carnage Heart EZ (Easy Zapping)", 0],
-			["SuperLite 1500 Series - Carnage Heart EZ (Easy Zapping)", 0]
+		"Carnage Heart EZ (Easy Zapping)": [
+			["SuperLite 1500 Series - Carnage Heart EZ (Easy Zapping)", 2]
 		],
 		"Castlevania - Symphony of the Night": [
 			["Akumajou Dracula X - Gekka no Yasoukyoku", 1]


### PR DESCRIPTION
Carnage Heart EZ was wrongly merged with Carnage Heart (the former is an Japan-only update of the latter)