### PR TITLE
Fix scheme for some recent No Intro dats

### DIFF
--- a/datafile.dtd
+++ b/datafile.dtd
@@ -64,7 +64,7 @@
 		<!ELEMENT game_id (#PCDATA)>
 		<!ELEMENT rom EMPTY>
 			<!ATTLIST rom name CDATA #REQUIRED>
-			<!ATTLIST rom size CDATA #REQUIRED>
+			<!ATTLIST rom size CDATA #IMPLIED>
 			<!ATTLIST rom crc CDATA #IMPLIED>
 			<!ATTLIST rom sha1 CDATA #IMPLIED>
 			<!ATTLIST rom md5 CDATA #IMPLIED>


### PR DESCRIPTION
There are games without size specified in the most recent dats, without this dtd scheme change those are marked as invalid and skipped by retool.