### PR TITLE
Update pyproject toml

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -50,31 +50,25 @@ the operating system you use.
         ```
 
     1.  Install Retool's dependencies, either with Pip or
-        [Poetry](https://python-poetry.org/):
+        [Hatch](https://hatch.pypa.io/):
 
         === "Pip"
             ```
             pip install alive-progress lxml psutil pyside6 darkdetect strictyaml validators
             ```
 
-        === "Poetry"
+        === "Hatch"
 
             1.  Install Poetry if you haven't already:
 
                 ```
-                pip install poetry
+                pip install hatch
                 ```
 
-            2.  Install Retool's dependencies:
+            2.  Enter the Hatch virtual environment:
 
                 ```
-                poetry install
-                ```
-
-            3.  Enter the Poetry virtual environment:
-
-                ```
-                poetry shell
+                hatch shell
                 ```
 
         !!! info

--- a/docs/download.md
+++ b/docs/download.md
@@ -54,21 +54,30 @@ the operating system you use.
 
         === "Pip"
             ```
-            pip install alive-progress lxml psutil pyside6 darkdetect strictyaml validators
+            pip install .
             ```
 
         === "Hatch"
 
-            1.  Install Poetry if you haven't already:
+            1.  Install Hatch if you haven't already:
 
                 ```
                 pip install hatch
                 ```
 
-            2.  Enter the Hatch virtual environment:
+            1.  Enter the Hatch virtual environment:
 
                 ```
                 hatch shell
+                ```
+
+                !!! info
+                    To exit the environment at any time, run the `exit` command.
+
+            1.  Install Retool's dependencies in the environment:
+
+                ```
+                pip install .
                 ```
 
         !!! info
@@ -78,18 +87,18 @@ the operating system you use.
     1.  Download the latest clone lists and metadata files:
 
         ```
-        retool.py --update
+        retool --update
         ```
 
         !!! info
             On some operating systems you might need to prefix Python files with `python3`
             or `python` to run them.
 
-    1.  You can now run `retool.py` or `retoolgui.py` with Python.
+    1.  You can now run `retool` or `retoolgui`.
 
     **Linux issues**
 
-    If you get a libxcb error in Linux when launching `retoolgui.py`, this fixed
+    If you get a libxcb error in Linux when launching `retoolgui`, this fixed
     the problem for me in Ubuntu 20.04:
 
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,34 +36,6 @@ Source = "https://github.com/unexpectedpanda/retool"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-#  Poetry
-[tool.poetry]
-name = "Retool"
-version = "2.02.2"
-description = "A better filter tool for Redump and No-Intro DATs"
-authors = ["unexpectedpanda <fake@example.com>"]
-license = "BSD-3-Clause"
-readme = "readme.md"
-packages = [
-	{include = "modules"},
-	{include = "retool.py"},
-	{include = "retoolgui.py"},
-]
-
-[tool.poetry.dependencies]
-python = ">=3.10"
-strictyaml = "^1.6.2"
-lxml = "^4.9.2"
-PySide6 = "^6.4.2"
-validators = "^0.20.0"
-alive-progress = "^3.0.1"
-psutil = "^5.9.4"
-darkdetect = "^0.8.0"
-
-[tool.poetry.scripts]
-retool = "retool:main"
-retoolgui = "retoolgui:main"
-
 # Hatch
 [[tool.hatch.envs.all.matrix]]
 python = ["3.10", "3.11", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ Source = "https://github.com/unexpectedpanda/retool"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[project.scripts]
+retool = "retool:main"
+retoolgui = "retoolgui:main"
+
 # Hatch
 [[tool.hatch.envs.all.matrix]]
 python = ["3.10", "3.11", "3.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ retool = "retool:main"
 retoolgui = "retoolgui:main"
 
 # Hatch
+[tool.hatch.build.targets.wheel]
+packages = ["retool.py", "retoolgui.py", "modules"]
+
 [[tool.hatch.envs.all.matrix]]
 python = ["3.10", "3.11", "3.12"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,24 +7,24 @@ requires-python = ">=3.10"
 license = {file = "LICENSE"}
 keywords = ["filter", "1G1R", "Redump", "No-Intro", "DAT"]
 authors = [
-  {name = "unexpectedpanda", email = "fake@example.com"},
+{name = "unexpectedpanda", email = "fake@example.com"},
 ]
 classifiers = [
-  "Development Status :: 5 - Production/Stable",
-  "License :: OSI Approved :: BSD License",
-  "Operating System :: OS Independent",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-	"alive-progress >= 3.0.1",
-	"darkdetect >= 0.8.0",
-	"lxml >= 4.9.2",
-	"psutil >= 5.9.4",
-	"PySide6 >= 6.4.2",
-	"strictyaml >= 1.6.2",
-	"validators >= 0.20.0",
+    "alive-progress >= 3.0.1",
+    "darkdetect >= 0.8.0",
+    "lxml >= 4.9.2",
+    "psutil >= 5.9.4",
+    "PySide6 >= 6.4.2",
+    "strictyaml >= 1.6.2",
+    "validators >= 0.20.0",
 ]
 
 [project.urls]
@@ -104,13 +104,13 @@ format = [
 # Hatch types setup and scripts
 [tool.hatch.envs.types]
 dependencies = [
-  "mypy>=1.8.0",
+    "mypy>=1.8.0",
 ]
 
 [tool.hatch.envs.types.scripts]
 check = [
     "mypy --strict --install-types --non-interactive --python-version=3.10 retoolgui.py tests",
-    ]
+]
 
 # Hatch tool configuration
 [tool.black]


### PR DESCRIPTION
It seems the recent versions of `retool` migrated from Poetry to Hatch for build system. This broke the packaging (missing script entry points), so I am providing fixes. This should get something like this working again:

```console
$ hatch build # will build wheels
$ hatch shell # start a development environment
$ python3 -m retool # run retool from the development environment
```

Also I did some formatting in `pyproject.toml` and updated the docs. If this is unwanted I can revert the changes.